### PR TITLE
Get tile server hostname from env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN chmod +x map-tiles.sh
 ENV OFFSET_X="0.0"
 # shift the map up (positive) or down (negative) by this many meters
 ENV OFFSET_Y="0.0"
+# tileserver to use for the preview app
+ENV TILE_SERVER="localhost:5000"
 
 EXPOSE 5000 5010
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run -ti --rm \
 
 This will split the given TIF file to different color bands (required by `terracotta`) and start both, the tile server and the preview GUI.
 
-Open `http://localhost:5010` and select `alpha` in the Bands list. Then select `rgb` in the `Customize layer` dropdown. Assign R, G and B bands their corresponding values and you should see the map.
+Open preview GUI on `http://localhost:5010` and select `alpha` in the Bands list. Then select `rgb` in the `Customize layer` dropdown. Assign R, G and B bands their corresponding values and you should see the map.
 
 ![preview][]
 
@@ -59,7 +59,15 @@ Copy the ortophoto file `odm_orthophoto.tif` to the OpenMower:
 scp odm_orthophoto.tif openmower@openmower.local:
 ```
 
-Copy the [`map-tiles.service`][map-tiles-service] file in `/etc/systemd/system/` on your OpenMower. Then enable and start the service:
+Copy the [`map-tiles.service`][map-tiles-service] file in `/etc/systemd/system/` on your OpenMower.
+
+If you want to use the preview GUI from the OpenMower, you will have to set the OpenMower IP address in the `ExecStart` command:
+
+```bash
+--env TILE_SERVER="<open-mower-ip>:5000" \
+```
+
+Then enable and start the service:
 
 ```bash
 sudo systemctl enable map-tiles.service

--- a/justfile
+++ b/justfile
@@ -1,12 +1,13 @@
 docker-build:
     docker build . -t openmower-map-tiles
 
-docker-run mapfile offset_x offset_y:
+docker-run mapfile tile_server offset_x offset_y:
     docker run -it --rm \
         -v {{mapfile}}:/tiles/map.tif \
         --name openmower-map-tiles \
         --env OFFSET_X={{offset_x}} \
         --env OFFSET_Y={{offset_y}} \
+        --env TILE_SERVER={{tile_server}} \
         -p 5000:5000 \
         -p 5010:5010 \
         openmower-map-tiles

--- a/map-tiles.service
+++ b/map-tiles.service
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/podman run \
   --network host \
   --env OFFSET_X=0 \
   --env OFFSET_Y=0 \
+  --env TILE_SERVER="localhost:5000" \
   --volume /home/openmower/odm_orthophoto.tif:/tiles/map.tif \
   ghcr.io/2m/openmower-map-tiles:main
 

--- a/map-tiles.sh
+++ b/map-tiles.sh
@@ -41,8 +41,8 @@ echo "${green}Starting XYZ tile server${normal}"
 terracotta serve --allow-all-ips -r "optimized/{}_{band}.tif" &
 sleep 5
 
-echo "${green}Starting preview server${normal}"
-terracotta connect localhost:5000 &
+echo "${green}Starting preview server that will use tile server on $TILE_SERVER${normal}"
+terracotta connect "$TILE_SERVER" &
 
 # "terracotta connect" listens to localhost
 # this forwards connections from all interfaces to localhost


### PR DESCRIPTION
This needs to be explicitly set when accessing preview GUI from anything else than localhost.