### PR TITLE
Expose caddy config volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ ENV TC_DRIVER_PATH="/tiles/terracotta.sqlite"
 # Cloudflare API token for TLS DNS challenge
 ENV CF_API_TOKEN=""
 
+# See https://caddyserver.com/docs/conventions#file-locations for details
+ENV XDG_CONFIG_HOME /config
+ENV XDG_DATA_HOME /data
+
 EXPOSE 5000 5010 5443
 
 CMD ./map-tiles.sh

--- a/map-tiles.service
+++ b/map-tiles.service
@@ -25,6 +25,8 @@ ExecStart=/usr/bin/podman run \
   --env OFFSET_Y=0 \
   --env TILE_SERVER="localhost" \
   --volume /home/openmower/odm_orthophoto.tif:/tiles/map.tif \
+  --volume caddy_data:/data \
+  --volume caddy_config:/config \
   ghcr.io/2m/openmower-map-tiles:main
 
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-map-tiles.ctr-id -t 10


### PR DESCRIPTION
This is to keep TLS certificates between container reboots. Letsencrypt has 5certs/week limit which can be easily reached if the mower gets restarted frequently.